### PR TITLE
Fixing maximumParkingDuration property

### DIFF
--- a/OffStreetParking/schema.json
+++ b/OffStreetParking/schema.json
@@ -302,7 +302,7 @@
         "lowestFloor": {
           "type": "integer"
         },
-        "maximumAllowedDuration": {
+        "maximumParkingDuration": {
           "type": "string"
         },
         "totalSpotNumber": {


### PR DESCRIPTION
The previous maximumAllowedDuration property do not match with the description nor the examples in the README. It should be instead the "maximumParkingDuration" property.

If the right name is "maximumAllowedDuration" then should be fixed in the README.md